### PR TITLE
Gameplay restrictions toggle

### DIFF
--- a/2016.html
+++ b/2016.html
@@ -59,6 +59,9 @@
 					<br>
 					<input type="checkbox" id="generic" value="true" checked>
 					<div class="tooltip"><label for="generic">Generic kills</label><span class="tooltiptext">Non-specific kills can appear as kill methods<br><br>Accident, melee weapon (large), firearm...</span></div>
+					<br>
+					<input type="checkbox" id="restrictions" value="true" checked>
+					<div class="tooltip"><label for="restrictions">Allow restrictions</label><span class="tooltiptext">Occasionally adds playstyle restrictions, such as "Do not throw items as distractions."</span></div>
 				</section>
 
 				<p id="chosenmission"></p>

--- a/2016mini.html
+++ b/2016mini.html
@@ -43,6 +43,9 @@
 					<input type="checkbox" id="accident" value="true" checked>Specific accidents
 					<br>
 					<input type="checkbox" id="generic" value="true" checked>Generic kills
+					<br>
+					<input type="checkbox" id="restrictions" value="true" checked>
+					Allow restrictions
 				</section>
 
 				<p id="chosenmission"></p>

--- a/js/2016new.js
+++ b/js/2016new.js
@@ -1,116 +1,22 @@
 //Creates the object that will be used as a source for the mission objectives
 function createContainerObject() {
 	var missionIndex = document.getElementById("missionselect");
-	var mission = missionIndex.options[missionIndex.selectedIndex].value;
+	var mission_name = missionIndex.options[missionIndex.selectedIndex].value;
 	var randomMissionList = [showstopper,hh,wot,agc,icon,landslide,ahbos,c27,ff,si];
 	
-	for (var prop in generic) {
-		if (generic.hasOwnProperty(prop)) {
+	for (var prop in generic)
+		if (generic.hasOwnProperty(prop))
 			container[prop] = generic[prop];
-		}
-	}
-	switch(mission) {
-		case "RANDOM": 
-		{
-			randomMission = randomMissionList[Math.floor(Math.random()*randomMissionList.length)];
-			for (var prop in randomMission) {
-				if (randomMission.hasOwnProperty(prop)) {
-					container[prop] = randomMission[prop];
-				}
-			}
-			break;
-		}
-		case "TSS": 
-		{
-			for (var prop in showstopper) {
-				if (showstopper.hasOwnProperty(prop)) {
-					container[prop] = showstopper[prop];
-				}
-			}
-			break;
-		}
-		case "HH": 
-		{
-			for (var prop in hh) {
-				if (hh.hasOwnProperty(prop)) {
-					container[prop] = hh[prop];
-				}
-			}
-			break;
-		}
-		case "WOT": 
-		{
-			for (var prop in wot) {
-				if (wot.hasOwnProperty(prop)) {
-					container[prop] = wot[prop];
-				}
-			}
-			break;
-		}
-		case "ICON": 
-		{
-			for (var prop in icon) {
-				if (agc.hasOwnProperty(prop)) {
-					container[prop] = icon[prop];
-				}
-			}
-			break;
-		}
-		case "LS": 
-		{
-			for (var prop in landslide) {
-				if (landslide.hasOwnProperty(prop)) {
-					container[prop] = landslide[prop];
-				}
-			}
-			break;
-		}
-		case "AGC": 
-		{
-			for (var prop in agc) {
-				if (icon.hasOwnProperty(prop)) {
-					container[prop] = agc[prop];
-				}
-			}
-			break;
-		}
-		case "AHBOS": 
-		{
-			for (var prop in ahbos) {
-				if (ahbos.hasOwnProperty(prop)) {
-					container[prop] = ahbos[prop];
-				}
-			}
-			break;
-		}
-		case "C27": 
-		{
-			for (var prop in c27) {
-				if (c27.hasOwnProperty(prop)) {
-					container[prop] = c27[prop];
-				}
-			}
-			break;
-		}
-		case "FF": 
-		{
-			for (var prop in ff) {
-				if (ff.hasOwnProperty(prop)) {
-					container[prop] = ff[prop];
-				}
-			}
-			break;
-		}
-		case "SI": 
-		{
-			for (var prop in si) {
-				if (si.hasOwnProperty(prop)) {
-					container[prop] = si[prop];
-				}
-			}
-			break;
-		}
-	}
+	
+	// Javascript scope rules are hilarious 
+	if(mission_name === "RANDOM")
+		var current_mission = randomMissionList[Math.floor(Math.random()*randomMissionList.length)];
+	else
+		var current_mission = mission_names_map[mission_name];
+	
+	for (var prop in current_mission)
+		if(current_mission.hasOwnProperty(prop))
+			container[prop] = current_mission[prop];
 };
 
 //Makes sure old results are cleared when new objectives are randomized
@@ -119,11 +25,10 @@ function clearAll() {
 	container = {};
 	result = {};
 	document.getElementById("info").innerHTML = "";
-
 };
 
 //Hides unused html elements that appear in some results
-function removeUndefined() {
+function removeUndefined() {	
 	if ("undefined" === typeof result.target2) {
 		document.getElementById("kill2").innerHTML = "";
 	}
@@ -160,27 +65,27 @@ function removeUndefined() {
 //Randomizes extra variables for the result
 function extras() {
 	
-if (Math.random() < 0.09 && document.getElementById("disguise").checked == 0) {
+if (Math.random() < 0.12 && document.getElementById("disguise").checked == 0) {
 	result.extra1 = "Never change into a new disguise.";
 }
 
-if (Math.random() < 0.19 && document.getElementById("disguise").checked == 0) {
+if (Math.random() < 0.25 && document.getElementById("disguise").checked == 0) {
 	result.extra2 = "Do not kill or subdue non-targets.";
 }
 
-if (Math.random() < 0.14) {
+if (Math.random() < 0.18) {
 	result.extra3 = "Do not throw items as distractions.";
 }
 
-if (Math.random() < 0.19) {
+if (Math.random() < 0.25) {
 	result.extra4 = "Do not use firearms as distractions or to destroy objects.";
 }
 
-if (Math.random() < 0.09) {
+if (Math.random() < 0.12) {
 	result.extra5 = "Do not climb.";
 }
 
-if (Math.random() < 0.04) {
+if (Math.random() < 0.05) {
 	result.extra6 = "Do not crouch.";
 }
 
@@ -331,7 +236,8 @@ function literallyEverything() {
 	containerToResult();
 	disguisesOn();
 	targetsAndKills();
-	extras();
+	if(document.getElementById("restrictions").checked)
+		extras();
 	writeEverything();
 	removeUndefined();
 };

--- a/js/2016new2.js
+++ b/js/2016new2.js
@@ -112,3 +112,16 @@ var si = {
 	sodersKills: ["Throw the Heart into the Trash Can","Shoot the Heart","Electricution","Pistol","Large Firearm","Explosion","Poison the Stem Cells","Reveal Yourself as 47","Fail the Surgery","Make the Surgeon Fail the Surgery","Robot Arms"],
 	disguises: ["Ninja","47 in his Suit","Baseball Player","Bodyguard","Chef","Chief Surgeon","Doctor","Handyman","Helicopter Pilot","Hospital Director","Morgue Doctor","Motorcyclist","Patient","Resort Security","Resort Staff","Surgeon","VIP Patient (Dexter)","VIP Patient (Portman)","Yoga Instructor"]
 };
+
+var mission_names_map = {
+	"TSS" : showstopper,
+	"HH": hh,
+	"WOT": wot,
+	"ICON": icon,
+	"LS": landslide,
+	"AGC": agc,
+	"AHBOS": ahbos,
+	"C27": c27,
+	"FF": ff,
+	"SI": si
+}


### PR DESCRIPTION
Hey @TheKotti,
Added an extra option enabling the "extras" restrictions, and raised the chance of each of them appearing by a small percentage to justify having it in the first place; also took the liberty of refactoring the "CreateContainerObject" function to make it just a tad more readable.

Let me know if either one of this changes is something you like, or if you're fine with me contributing at all. If so, I'd also like to try and eliminate other instances of the code repetition here, and potentially add new features like roulette history(an undo button).

Also - I'm not entirely sure on this, but I think it should be fairly easy to embed the contents of the popout version into the regular page of the roulette, so that you don't need to have two distinct files with the same code inside. Is there any other reason for the 2016mini file? I noticed that it doesn't have the alt-text descriptions in options, so maybe you just wanted it to be more lightweight.