### PR TITLE
Full rewrite and history buttons

### DIFF
--- a/2016.html
+++ b/2016.html
@@ -19,72 +19,17 @@
 		</nav>
 	
 		<section id="roulettesection">
-
-				<select id="missionselect">
-					<option value="RANDOM">Random Mission</option>
-					<option value="TSS">The Showstopper</option>
-					<option value="HH">Holiday Hoarders</option>
-					<option value="WOT">World of Tomorrow</option>
-					<option value="ICON">The Icon</option>
-					<option value="LS">Landslide</option>
-					<option value="AGC">A Gilded Cage</option>
-					<option value="AHBOS">A House Built on Sand</option>
-					<option value="C27">Club 27</option>
-					<option value="FF">Freedom Fighters</option>
-					<option value="SI">Situs Inversus</option>
-				</select>
-				<button type="button" class="nappi" onclick="button_MakeItGo()">Make it go</button>
-				<button type="button" id="filterbutton" class="nappi" onclick="showFilters()">Hide options</button>
 				<a id="popoutnappi" href="roulettemini.html"  onclick="window.open('2016mini.html', 'newwindow', 'width=375, height=600'); return false;">Popout</a>
-				<br>
-				<section id="filters">
-					<select id="modeselect">
-						<option value="MAIN">Main mission</option>
-						<option value="CONTRACTS">Contracts mode</option>
-						<option value="ELUSIVE">Elusive target</option>
-					</select>
-					<a id="contractinfonappi" href="roulettemini.html"  onclick="window.open('contracts.html', 'newwindow', 'width=450, height=600'); return false;">(Contracts mode info)</a>
-					<br>
-					<input type="checkbox" id="disguise" value="true" checked>
-					<div class="tooltip"><label for="disguise">Specific disguises</label><span class="tooltiptext">Adds a random disguise requirement for each kill.</span></div>
-					<br>
-					<input type="checkbox" id="melee" value="true" checked>
-					<div class="tooltip"><label for="melee">Specific melee weapons</label><span class="tooltiptext">Mission specific melee weapons can appear as kill methods.<br><br>Fire axe, scissors, screwdriver...</span></div>
-					<br>
-					<input type="checkbox" id="firearm" value="true" checked>
-					<div class="tooltip"><label for="firearm">Specific firearms</label><span class="tooltiptext">Different firearm types can appear as kill methods.<br><br>Pistol, sniper rifle, explosive...</span></div>
-					<br>
-					<input type="checkbox" id="accident" value="true" checked>
-					<div class="tooltip"><label for="accident">Specific accidents</label><span class="tooltiptext">Specific accidents can appear as kill methods.<br><br>Drowning, falling object, explosion...</span></div>
-					<br>
-					<input type="checkbox" id="generic" value="true" checked>
-					<div class="tooltip"><label for="generic">Generic kills</label><span class="tooltiptext">Non-specific kills can appear as kill methods<br><br>Accident, melee weapon (large), firearm...</span></div>
-					<br>
-					<input type="checkbox" id="restrictions" value="true" checked>
-					<div class="tooltip"><label for="restrictions">Allow restrictions</label><span class="tooltiptext">Occasionally adds playstyle restrictions, such as "Do not throw items as distractions."</span></div>
-				</section>
-
-				<p id="chosenmission"></p>
-				<section id="resultsection">
-					<p id="start"></p>
-					<p id="kill1"></p>
-					<p id="kill2"></p>
-					<p id="kill3"></p>
-					<p id="kill4"></p>
-					<p id="kill5"></p>
-					<p id="exit"></p><br>
-					<p id="extra1" class="extras"></p>
-					<p id="extra2" class="extras"></p>
-					<p id="extra3" class="extras"></p>
-					<p id="extra4" class="extras"></p>
-					<p id="extra5" class="extras"></p>
-					<p id="extra6" class="extras"></p>
-					<p id="info"></p>
-				</section>
-
-				<script src="js/2016new.js"></script>
-				<script src="js/2016new2.js"></script> 
-
+				
+				<iframe
+					id="embed"
+					marginheight = 0
+					marginwidth = 0
+					width = 760
+					height = 600
+					src="2016mini.html"
+					frameborder = 0
+					></iframe>
 		</section>
 		
 		<footer>

--- a/2016.html
+++ b/2016.html
@@ -33,7 +33,7 @@
 					<option value="FF">Freedom Fighters</option>
 					<option value="SI">Situs Inversus</option>
 				</select>
-				<button type="button" class="nappi" onclick="literallyEverything()">Make it go</button>
+				<button type="button" class="nappi" onclick="button_MakeItGo()">Make it go</button>
 				<button type="button" id="filterbutton" class="nappi" onclick="showFilters()">Hide options</button>
 				<a id="popoutnappi" href="roulettemini.html"  onclick="window.open('2016mini.html', 'newwindow', 'width=375, height=600'); return false;">Popout</a>
 				<br>

--- a/2016.html
+++ b/2016.html
@@ -88,7 +88,7 @@
 		</section>
 		
 		<footer>
-			<p>By <a href="https://twitter.com/TheKotti">Kotti</a></p>
+			<p>By <a href="https://twitter.com/TheKotti">Kotti</a> | <a href="https://github.com/TheKotti/thekotti.github.io">Github</a> </p>
 		</footer>
 		
 	</body>

--- a/2016mini.html
+++ b/2016mini.html
@@ -23,7 +23,7 @@
 					<option value="FF">Freedom Fighters</option>
 					<option value="SI">Situs Inversus</option>
 				</select>
-				<button type="button" class="nappi" onclick="literallyEverything()">Make it go</button>
+				<button type="button" class="nappi" onclick="button_MakeItGo()">Make it go</button>
 				<button type="button" id="filterbutton" class="nappi" onclick="showFilters()">Hide options</button>
 				<br>
 				<section id="filters">

--- a/2016mini.html
+++ b/2016mini.html
@@ -37,18 +37,23 @@
 					</select>
 					<a id="contractinfonappi" href="roulettemini.html"  onclick="window.open('contracts.html', 'newwindow', 'width=450, height=600'); return false;">(Contracts mode info)</a>
 					<br>
-					<input type="checkbox" id="disguise" value="true" checked>Specific disguises
+					<input type="checkbox" id="disguise" value="true" checked>
+					<div class="tooltip"><label for="disguise">Specific disguises</label><span class="tooltiptext">Adds a random disguise requirement for each kill.</span></div>
 					<br>
-					<input type="checkbox" id="melee" value="true" checked>Specific melee weapons
+					<input type="checkbox" id="melee" value="true" checked>
+					<div class="tooltip"><label for="melee">Specific melee weapons</label><span class="tooltiptext">Mission specific melee weapons can appear as kill methods.<br><br>Fire axe, scissors, screwdriver...</span></div>
 					<br>
-					<input type="checkbox" id="firearm" value="true" checked>Specific firearms
+					<input type="checkbox" id="firearm" value="true" checked>
+					<div class="tooltip"><label for="firearm">Specific firearms</label><span class="tooltiptext">Different firearm types can appear as kill methods.<br><br>Pistol, sniper rifle, explosive...</span></div>
 					<br>
-					<input type="checkbox" id="accident" value="true" checked>Specific accidents
+					<input type="checkbox" id="accident" value="true" checked>
+					<div class="tooltip"><label for="accident">Specific accidents</label><span class="tooltiptext">Specific accidents can appear as kill methods.<br><br>Drowning, falling object, explosion...</span></div>
 					<br>
-					<input type="checkbox" id="generic" value="true" checked>Generic kills
+					<input type="checkbox" id="generic" value="true" checked>
+					<div class="tooltip"><label for="generic">Generic kills</label><span class="tooltiptext">Non-specific kills can appear as kill methods<br><br>Accident, melee weapon (large), firearm...</span></div>
 					<br>
 					<input type="checkbox" id="restrictions" value="true" checked>
-					Allow restrictions
+					<div class="tooltip"><label for="restrictions">Allow restrictions</label><span class="tooltiptext">Occasionally adds playstyle restrictions, such as "Do not throw items as distractions."</span></div>
 				</section>
 
 				<p id="chosenmission"></p>

--- a/2016mini.html
+++ b/2016mini.html
@@ -26,8 +26,8 @@
 				<button type="button" class="nappi" onclick="button_MakeItGo()">Make it go</button>
 				<button type="button" id="filterbutton" class="nappi" onclick="showFilters()">Hide options</button>
 				<br>
-				<button type="button" class="nappi" onclick="history_undo()">Undo</button>
-				<button type="button" class="nappi" onclick="history_redo()">Redo</button>
+				<button type="button" id="undo_nappi" disabled = "true" class="nappi" onclick="history_undo()">Undo</button>
+				<button type="button" id="redo_nappi" disabled = "true" class="nappi" onclick="history_redo()">Redo</button>
 				<br>
 				<section id="filters">
 					<select id="modeselect">

--- a/2016mini.html
+++ b/2016mini.html
@@ -26,6 +26,9 @@
 				<button type="button" class="nappi" onclick="button_MakeItGo()">Make it go</button>
 				<button type="button" id="filterbutton" class="nappi" onclick="showFilters()">Hide options</button>
 				<br>
+				<button type="button" class="nappi" onclick="history_undo()">Undo</button>
+				<button type="button" class="nappi" onclick="history_redo()">Redo</button>
+				<br>
 				<section id="filters">
 					<select id="modeselect">
 						<option value="MAIN">Main mission</option>

--- a/about.html
+++ b/about.html
@@ -100,7 +100,7 @@
 		</section>
 		
 		<footer>
-			<p>By <a href="https://twitter.com/TheKotti">Kotti</a></p>
+			<p>By <a href="https://twitter.com/TheKotti">Kotti</a> | <a href="https://github.com/TheKotti/thekotti.github.io">Github</a> </p>
 		</footer>
 		
 	</body>

--- a/css/2016.css
+++ b/css/2016.css
@@ -2,62 +2,7 @@
 	height:600px;
 }
 
-#resultsection {
-	line-height:1.2;
-	margin-top:20px;
-	border: none;
-	padding: 0;
-	margin: 0;
-}
-
-#resultsection p {
-	margin-top: 1px;
-	margin-bottom: 1px;
-}
-
-#chosenmission {
-	font-size:18px;
-	font-weight: bold;
-	color:#cc0000;
-}
-
 #popoutnappi {
-	float:right;
-}
-
-#info {
-	color: green;
-	padding-top: 15px;
-}
-
-#filters {
-	border: none;
-	padding-left: 0;
-	padding-top: 0;
-	padding-bottom: 20px;
-	display:block;
-}
-
-.bluetext {
-	margin: 0;
-	padding: 0;
-	color: blue;
-	display: inline;
-}
-
-.redtext {
-	margin: 0;
-	padding: 0;
-	color: red;
-	display: inline;
-}
-
-.extras {
-	margin: 0;
-	padding: 0;
-	color: blue;
-}
-
-.nappi {
-	display: inline;
+	position: absolute;
+	margin-left: 674px;
 }

--- a/css/mini.css
+++ b/css/mini.css
@@ -62,3 +62,31 @@
 .nappi {
 	display: inline;
 }
+
+/* Tooltip container */
+.tooltip {
+    position: relative;
+    display: inline-block;
+}
+
+/* Tooltip text */
+.tooltip .tooltiptext {
+    visibility: hidden;
+    width: 200px;
+    background-color: black;
+    color: #fff;
+    text-align: center;
+    padding: 5px 0;
+    border-radius: 6px;
+ 
+    /* Position the tooltip text - see examples below! */
+    position: absolute;
+    z-index: 1;
+	top: -5px;
+    left: 105%; 
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+.tooltip:hover .tooltiptext {
+    visibility: visible;
+}

--- a/js/2016new.js
+++ b/js/2016new.js
@@ -187,6 +187,37 @@ function generate_result() {
 function button_MakeItGo(){
 	var result = generate_result();
 	writeEverything(result);
+	history_push(result);
+}
+
+//adds x to the history stack for a maximum of 20 most recent runs
+//forgets all results more recent than the last selected (blocks redo)
+function history_push(x){
+	redo_stack = [];
+	history_past.push(x);
+	if(history_past.length > 20)
+		history_past.shift();
+}
+
+
+// undo and redo functions, affect global state
+function history_undo(){
+	if(history_past.length < 2)
+		return;
+	
+	//add the currently displayed result to the redo stack
+	redo_stack.push(history_past.pop());
+	var previous = history_past[history_past.length - 1];
+	writeEverything(previous);
+}
+
+function history_redo(){
+	if(redo_stack.length < 1)
+		return;
+	
+	history_past.push(redo_stack.pop());
+	var previous = history_past[history_past.length - 1];
+	writeEverything(previous);
 }
 
 //Displays/hides the options

--- a/js/2016new.js
+++ b/js/2016new.js
@@ -191,12 +191,17 @@ function button_MakeItGo(){
 }
 
 //adds x to the history stack for a maximum of 20 most recent runs
-//forgets all results more recent than the last selected (blocks redo)
 function history_push(x){
 	redo_stack = [];
 	history_past.push(x);
 	if(history_past.length > 20)
 		history_past.shift();
+	
+	//history exists, enable undo_nappi
+	if(history_past.length > 1)
+		document.getElementById("undo_nappi").disabled = false;
+	// disable redo_nappi
+	document.getElementById("redo_nappi").disabled = true;
 }
 
 
@@ -209,6 +214,12 @@ function history_undo(){
 	redo_stack.push(history_past.pop());
 	var previous = history_past[history_past.length - 1];
 	writeEverything(previous);
+	
+	// enable redo_nappi
+	document.getElementById("redo_nappi").disabled = false;
+	//history exists, enable undo_nappi
+	if(history_past.length < 2)
+		document.getElementById("undo_nappi").disabled = true;
 }
 
 function history_redo(){
@@ -218,6 +229,14 @@ function history_redo(){
 	history_past.push(redo_stack.pop());
 	var previous = history_past[history_past.length - 1];
 	writeEverything(previous);
+	
+	
+	//history exists, enable undo_nappi
+	if(history_past.length > 1)
+		document.getElementById("undo_nappi").disabled = false;
+	// disable redo_nappi
+	if(redo_stack.length < 1)
+		document.getElementById("redo_nappi").disabled = true;
 }
 
 //Displays/hides the options

--- a/js/2016new.js
+++ b/js/2016new.js
@@ -8,7 +8,6 @@ function createContainerObject() {
 		if (generic.hasOwnProperty(prop))
 			container[prop] = generic[prop];
 	
-	// Javascript scope rules are hilarious 
 	if(mission_name === "RANDOM")
 		var current_mission = randomMissionList[Math.floor(Math.random()*randomMissionList.length)];
 	else
@@ -17,6 +16,9 @@ function createContainerObject() {
 	for (var prop in current_mission)
 		if(current_mission.hasOwnProperty(prop))
 			container[prop] = current_mission[prop];
+	
+	// Create a copy to avoid modifying the originals
+	container.disguises = current_mission.disguises.slice()
 };
 
 //Makes sure old results are cleared when new objectives are randomized
@@ -92,48 +94,34 @@ if (Math.random() < 0.05) {
 };
 
 //Creates the list of weapons/accidents from which the kill methods are pulled
+
+// TODO: Turn into a pure function
 function createWeaponList() {
-	if (document.getElementById("melee").checked == 1) {
-		for (i = 0; i < container.melee.length; i++) {
-			killList.push(container.melee[i])
-		}
-	}
-	if (document.getElementById("firearm").checked == 1) {
-		for (i = 0; i < container.firearms.length; i++) {
-			killList.push(container.firearms[i])
-		}
-	}
-	if (document.getElementById("accident").checked == 1) {
-		for (i = 0; i < container.accidents.length; i++) {
-			killList.push(container.accidents[i])
-		}
-	}
-	if (document.getElementById("generic").checked == 1) {
-		for (i = 0; i < container.kills.length; i++) {
-			killList.push(container.kills[i])
-		}
-	}
-	if (document.getElementById("melee").checked == 0 && document.getElementById("firearm").checked == 0 && document.getElementById("accident").checked == 0 && document.getElementById("generic").checked == 0) {
+	if (document.getElementById("melee").checked)
+		killList = killList.concat(container.melee);
+			
+	if (document.getElementById("firearm").checked)
+		killList = killList.concat(container.firearms);
+	
+	if (document.getElementById("accident").checked)
+		killList = killList.concat(container.accidents);
+	
+	if (document.getElementById("generic").checked)
+		killList = killList.concat(container.kills);
+	
+	var no_weapons_selected = !(killList.length > 0);
+	if (no_weapons_selected)
 		killList.push("No weapons selected!");
-	}
 };
 
+// Removes "Ninja" and "47 in his Suit" from potential disguises
+// when starting in an undercover location
 function disguisesOn() {
-	var startIndex = suitStarts.indexOf(result.entry);
+	var undercover_start = suitStarts.indexOf(result.entry) === -1;
 	
-	if (result.missionTitle == "Situs Inversus") {
-		if (startIndex == -1 && container.disguises[0] == "Ninja") {
-			container.disguises.splice(0,1);
-		} else if (startIndex >= 0 && container.disguises[0] != "Ninja") {
-			container.disguises.unshift("Ninja");
-		}
-	} else {
-		if (startIndex == -1 && container.disguises[0] == "47 in his Suit") {
-			container.disguises.splice(0,1);
-		} else if (startIndex >= 0 && container.disguises[0] != "47 in his Suit") {
-			container.disguises.unshift("47 in his Suit");
-		}
-	}
+	if (undercover_start)
+		container.disguises.splice(0,1);
+		// The first disguise in the list is always the non-undercover one
 }
 
 //Chooses targets and kill methods

--- a/js/2016new.js
+++ b/js/2016new.js
@@ -108,11 +108,11 @@ function createTargetList(container) {
 	var mode = modeIndex.options[modeIndex.selectedIndex].value;
 	if (mode == "CONTRACTS") {
 		var targetAmountCheck = Math.random();
-		result.num_targets = 5;
-		if (targetAmountCheck < 0.84) result.num_targets--;
-		if (targetAmountCheck < 0.69) result.num_targets--;
-		if (targetAmountCheck < 0.39) result.num_targets--;
-		if (targetAmountCheck < 0.04) result.num_targets--;
+		var num_targets = 5;
+		if (targetAmountCheck < 0.84) num_targets--;
+		if (targetAmountCheck < 0.69) num_targets--;
+		if (targetAmountCheck < 0.39) num_targets--;
+		if (targetAmountCheck < 0.04) num_targets--;
 		
 		shuffle(container.targetList);
 		targets = container.contractTargets.slice(0, num_targets);

--- a/js/2016new.js
+++ b/js/2016new.js
@@ -46,6 +46,7 @@ function removeUndefined() {
 };
 
 //Randomizes extra variables for the result
+// TODO: Turn into data
 function extras() {
 	
 if (Math.random() < 0.12 && document.getElementById("disguise").checked == 0) {
@@ -109,60 +110,47 @@ function disguisesOn() {
 function targetsAndKills() {
 	var modeIndex = document.getElementById("modeselect");
 	var mode = modeIndex.options[modeIndex.selectedIndex].value;
-	var missionIndex = document.getElementById("missionselect");
-	var mission = missionIndex.options[missionIndex.selectedIndex].value;
 	
 	if (mode == "CONTRACTS") {
 		container.targetList = container.contractTargets;
 		shuffle(container.targetList);
 	}
-	if (mode == "ELUSIVE") {
+	if (mode == "ELUSIVE")
 		container.targetList = ["Elusive Target"];
-	}
 	
-	result.target1 = container.targetList[0];
-	result.weapon1 = killList[Math.floor(Math.random()*killList.length)];
-	result.target2 = container.targetList[1];
-	result.weapon2 = killList[Math.floor(Math.random()*killList.length)];
-	result.target3 = container.targetList[2];
-	result.weapon3 = killList[Math.floor(Math.random()*killList.length)];
-	result.target4 = container.targetList[3];
-	result.weapon4 = killList[Math.floor(Math.random()*killList.length)];
-	result.target5 = container.targetList[4];
-	result.weapon5 = killList[Math.floor(Math.random()*killList.length)];
+	// Copy the target list
+	result.targets = container.targetList.slice();
+	// Randomize weapons
+	shuffle(killList);
+	result.weapons = killList;
 		
 	if (mode == "CONTRACTS") {
 		var targetAmountCheck = Math.random();
 		if (targetAmountCheck < 0.84) {
-			result.target5 = undefined;
+			result.targets[4] = undefined;
 		}
 		if (targetAmountCheck < 0.69) {
-			result.target4 = undefined;
+			result.targets[3] = undefined;
 		}
 		if (targetAmountCheck < 0.39) {
-			result.target3 = undefined;
+			result.targets[2] = undefined;
 		}
 		if (targetAmountCheck < 0.04) {
-			result.target2 = undefined;
+			result.targets[1] = undefined;
 		}
 	}
 	
-	if (document.getElementById("disguise").checked == 1)  {
-		result.disguise1 = " as " + container.disguises[Math.floor(Math.random()*container.disguises.length)];
-		result.disguise2 = " as " + container.disguises[Math.floor(Math.random()*container.disguises.length)];
-		result.disguise3 = " as " + container.disguises[Math.floor(Math.random()*container.disguises.length)];
-		result.disguise4 = " as " + container.disguises[Math.floor(Math.random()*container.disguises.length)];
-		result.disguise5 = " as " + container.disguises[Math.floor(Math.random()*container.disguises.length)];
-	} else {
-		result.disguise1 = "";
-		result.disguise2 = "";
-		result.disguise3 = "";
-		result.disguise4 = "";
-		result.disguise5 = "";
-	}
+	if (document.getElementById("disguise").checked)  {
+		//copy the disguise list, add  " as " to every element, then shuffle it
+		result.disguises =
+			container.disguises.slice().map(function(e){ return " as " + e; });
+		shuffle(result.disguises);
+	} else
+		result.disguises = ["", "", "", "", ""];
 	
+	// add Soders-specific kill if relevant
 	if (mode == "MAIN" && container.missionTitle === "Situs Inversus" && !(document.getElementById("melee").checked == 0 && document.getElementById("firearm").checked == 0 && document.getElementById("accident").checked == 0 && document.getElementById("generic").checked == 0)) {
-		result.weapon2 = container.sodersKills[Math.floor(Math.random()*container.sodersKills.length)];
+		result.weapons[1] = container.sodersKills[Math.floor(Math.random()*container.sodersKills.length)];
 	}
 };
 
@@ -176,25 +164,25 @@ function containerToResult() {
 //Makes text appear
 function writeEverything() {
 	document.getElementById("chosenmission").innerHTML = result.missionTitle;
-	document.getElementById("start").innerHTML = "<p class='bluetext'>Start</p>: " + result.entry;
-	document.getElementById("kill1").innerHTML = "<p class='redtext'>" + result.target1 + "</p>: " + result.weapon1 + result.disguise1;
-	document.getElementById("kill2").innerHTML = "<p class='redtext'>" + result.target2 + "</p>: " + result.weapon2 + result.disguise2;
-	document.getElementById("kill3").innerHTML = "<p class='redtext'>" + result.target3 + "</p>: " + result.weapon3 + result.disguise3;
-	document.getElementById("kill4").innerHTML = "<p class='redtext'>" + result.target4 + "</p>: " + result.weapon4 + result.disguise4;
-	document.getElementById("kill5").innerHTML = "<p class='redtext'>" + result.target5 + "</p>: " + result.weapon5 + result.disguise5;
-	document.getElementById("exit").innerHTML = "<p class='bluetext'>Exit</p>: " + result.exit;
-	document.getElementById("extra1").innerHTML = result.extra1;
-	document.getElementById("extra2").innerHTML = result.extra2;
-	document.getElementById("extra3").innerHTML = result.extra3;
-	document.getElementById("extra4").innerHTML = result.extra4;
-	document.getElementById("extra5").innerHTML = result.extra5;
-	document.getElementById("extra6").innerHTML = result.extra6;
+	document.getElementById("start").innerHTML =
+		"<p class='bluetext'>Start</p>: " + result.entry;
+	
+	for(var i = 0; i < 5; ++i)
+		document.getElementById("kill" + (i+1)).innerHTML = 
+			"<p class='redtext'>" + result.targets[i]
+			+ "</p>: " + result.weapons[i] + result.disguises[i];
+	
+	for(var i = 1; i < 7; ++i)
+		document.getElementById("extra" + i).innerHTML = result["extra"+i];
+	
+	document.getElementById("exit").innerHTML =
+		"<p class='bluetext'>Exit</p>: " + result.exit;
 	
 	var modeIndex = document.getElementById("modeselect");
 	var mode = modeIndex.options[modeIndex.selectedIndex].value;
-	if (result.missionTitle == "Freedom Fighters" && mode == "MAIN") {
-		document.getElementById("info").innerHTML = "To gain access to the exits, recreate the mission in Contracts mode."
-	}
+	if (result.missionTitle == "Freedom Fighters" && mode == "MAIN")
+		document.getElementById("info").innerHTML =
+			"To gain access to the exits, recreate the mission in Contracts mode.";
 };
 
 //All the things that should happen when you make it go
@@ -227,7 +215,7 @@ function showFilters() {
 //Shuffles an array
 function shuffle(array) {
   var m = array.length, t, i;
-
+  
   // While there remain elements to shuffle…
   while (m) {
 

--- a/js/2016new.js
+++ b/js/2016new.js
@@ -30,38 +30,19 @@ function clearAll() {
 };
 
 //Hides unused html elements that appear in some results
-function removeUndefined() {	
-	if ("undefined" === typeof result.target2) {
-		document.getElementById("kill2").innerHTML = "";
-	}
-	if ("undefined" === typeof result.target3) {
-		document.getElementById("kill3").innerHTML = "";
-	}
-	if ("undefined" === typeof result.target4) {
-		document.getElementById("kill4").innerHTML = "";
-	}
-	if ("undefined" === typeof result.target5) {
-		document.getElementById("kill5").innerHTML = "";
-	}
-	if ("undefined" === typeof result.extra1) {
-		document.getElementById("extra1").innerHTML = "";
-	}
-	if ("undefined" === typeof result.extra2) {
-		document.getElementById("extra2").innerHTML = "";
-	}
-	if ("undefined" === typeof result.extra3) {
-		document.getElementById("extra3").innerHTML = "";
-	}
-	if ("undefined" === typeof result.extra4) {
-		document.getElementById("extra4").innerHTML = "";
-	}
-	if ("undefined" === typeof result.extra5) {
-		document.getElementById("extra5").innerHTML = "";
-	}
-	if ("undefined" === typeof result.extra6) {
-		document.getElementById("extra6").innerHTML = "";
-	}
-
+function removeUndefined() { 
+	var optionals = [
+		"kill2", "kill3", "kill4", "kill5",
+		"extra1", "extra2", "extra3", "extra4", "extra5", "extra6"
+	]
+	
+	optionals.forEach( function(element){
+		var HTML_element = document.getElementById(element).innerHTML;
+		var missing = !(HTML_element.indexOf("undefined") === -1);
+	
+		if(missing)
+			document.getElementById(element).innerHTML = "";
+	});
 };
 
 //Randomizes extra variables for the result

--- a/js/2016new2.js
+++ b/js/2016new2.js
@@ -2,8 +2,6 @@ var result = {};
 
 var container = {};
 
-var killList = [];
-
 var suitStarts = ["Red Carpet","Palace Garden","Pile-Driver Barge","Attic","Undercover at IAGO Auction","Main Square","ICA Safe House","Harbor","Sapienza Ruins","Main Square Tower","Church Morgue","City gates","Promenade","Bazaar Entrance","Lamp Store Rooftop","School Alley","Consulate Parking Garage","Consulate plaza","Riverside Landing","47's Suite","West Bridge","Old Orchard","Southern Farm Perimeter","Water Tower","Infiltrating Along the Mountain Path"];
 
 var generic = {

--- a/js/2016new2.js
+++ b/js/2016new2.js
@@ -1,3 +1,7 @@
+// top of the history_past stack is the most recently displayed result
+var history_past = []
+var redo_stack = []
+
 var suitStarts = ["Red Carpet","Palace Garden","Pile-Driver Barge","Attic","Undercover at IAGO Auction","Main Square","ICA Safe House","Harbor","Sapienza Ruins","Main Square Tower","Church Morgue","City gates","Promenade","Bazaar Entrance","Lamp Store Rooftop","School Alley","Consulate Parking Garage","Consulate plaza","Riverside Landing","47's Suite","West Bridge","Old Orchard","Southern Farm Perimeter","Water Tower","Infiltrating Along the Mountain Path"];
 
 var generic = {

--- a/js/2016new2.js
+++ b/js/2016new2.js
@@ -1,7 +1,3 @@
-var result = {};
-
-var container = {};
-
 var suitStarts = ["Red Carpet","Palace Garden","Pile-Driver Barge","Attic","Undercover at IAGO Auction","Main Square","ICA Safe House","Harbor","Sapienza Ruins","Main Square Tower","Church Morgue","City gates","Promenade","Bazaar Entrance","Lamp Store Rooftop","School Alley","Consulate Parking Garage","Consulate plaza","Riverside Landing","47's Suite","West Bridge","Old Orchard","Southern Farm Perimeter","Water Tower","Infiltrating Along the Mountain Path"];
 
 var generic = {
@@ -122,4 +118,11 @@ var mission_names_map = {
 	"C27": c27,
 	"FF": ff,
 	"SI": si
+}
+
+var killTypesMap = {
+	"melee": "melee",
+	"firearm": "firearms",
+	"accident": "accidents",
+	"generic": "kills"
 }

--- a/roulette.html
+++ b/roulette.html
@@ -64,7 +64,7 @@
 		</section>
 		
 		<footer>
-			<p>By <a href="https://twitter.com/TheKotti">Kotti</a></p>
+			<p>By <a href="https://twitter.com/TheKotti">Kotti</a> | <a href="https://github.com/TheKotti/thekotti.github.io">Github</a> </p>
 		</footer>
 		
 	</body>


### PR DESCRIPTION
Since you gave me the go ahead, I made some small changes and rewrote everything to make future work easier:

\> Added the tooltips into the mini version, and the regular page now embeds the mini version. Makes it so there's only one version to edit.

\> Linked the GitHub repo in the footer

\> Added Undo/Redo buttons, pretty self-explanatory. 

\> Refactored nearly everything in the 2016new.js script:

- "LiterallyEverything()" is now split into button_MakeItGo() and generate_result(), which calls a few other functions to create the data.
- container, result and killList are no longer global, they're now returned by the appropriate functions.
- removeUndefined() and clearAll() are gone. There's no global state so they're no longer necessary, instead the other functions do the same work in a safer fashion.
- targetsAndKills() was split into createTargetList(), createWeaponList() and createDisguiseList() (which also merged with disguisesOn), since these functions don't share any logic.
- The history functions operate on the global arrays redo_stack[] and history_past[].

Reading https://github.com/TheKotti/thekotti.github.io/pull/2/files#diff-71da0b33170b56bb838b90e08892f2e9R174 should explain what's going on in the code now