### PR TITLE
Forgot to add names

### DIFF
--- a/contracts.html
+++ b/contracts.html
@@ -48,7 +48,6 @@
 			Renzo Forte - "Not Rocco"<br>
 			Salvatore Bravuomo - Lawyer<br>
 			Silvestro Pugliesi - Bohemian<br>
-			Luigi Saltatore - Green plumber<br>
 		<h4>Marrakesh (A Gilded Cage)</h4>
 			Ashraf Raghib Mustafa - Printing crew member<br>
 			Jeff Baker - Camera man<br>

--- a/contracts.html
+++ b/contracts.html
@@ -48,6 +48,7 @@
 			Renzo Forte - "Not Rocco"<br>
 			Salvatore Bravuomo - Lawyer<br>
 			Silvestro Pugliesi - Bohemian<br>
+			Luigi Saltatore - Green plumber<br>
 		<h4>Marrakesh (A Gilded Cage)</h4>
 			Ashraf Raghib Mustafa - Printing crew member<br>
 			Jeff Baker - Camera man<br>
@@ -77,6 +78,24 @@
 			Julian - Mr. Hungover<br>
 			Benjamin Bertam - Stalker<br>
 			Otis Kaplan - Ken Morgan's bodyguard<br>
+		<h4>Bangkok (The Source)</h4>
+			Robert Egg - Waitress outside in exhibition<br>
+			Akram - Cult Bodyguard<br>
+			Jeff - Defecting Cultist in the exhibition Bathroom<br>
+			Rebecca - Manipulative Cultist in the exhibition Bathroom <br>
+			Charles Slaughter - NPC with beige hat in the exhibition<br>
+			Jackie Carrington - Former Sitcom star<br>
+			Julian - Mr. Hungover<br>
+			Sam Harrison - Exhibition NPC with a yellow jumper tied around his waist<br>
+			Vipada Ahunai - Female Hotel Staff in the globe room<br>
+			Robert Uppey Jr - Cultist on the top floor<br>
+			Emily Carson - Cultist on the top floor<br>
+			Carl Wiley - Cultist on the top floor<br>
+			Timothy Lace - Cultist on the top floor<br>
+			Leila Tyduk - Cultist on the top floor<br>
+		        Louie Pan - Hotel Staff in the Globe Room<br>
+			Channarong - Security Guard on the pier<br>
+			A-Wut - Security Guard on the pier<br>
 		<h4>Colodaro</h4>
 			Quince Elliot - Explosives specialist<br>
 			Robert Powell - Militia cook<br>


### PR DESCRIPTION
When updating The Source for Contracts Mode, I forgot to add names to the contracts mode info popup.